### PR TITLE
mod.conf: define mod name

### DIFF
--- a/mod.conf
+++ b/mod.conf
@@ -1,0 +1,1 @@
+name = throwing


### PR DESCRIPTION
This allows a user to have the folder named differently and the mod will still load as `throwing`.

I am suggesting this because I am using [bower](https://minetest-bower.herokuapp.com/mods/throwing_redo) to install mods, and if I were to install this mod from there as it is currently listed, it would be loaded as `throwing_redo` instead.
